### PR TITLE
Use levenshtein_tabulation to be faster

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ use util::DistanceMatrix;
 /// assert_eq!(distance, 3);
 /// ```
 pub fn distance<T: PartialEq>(source: &[T], target: &[T]) -> (usize, DistanceMatrix) {
-    levenshtein_memoization(source, target)
+    levenshtein_tabulation(source, target)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Benchmarks show that levenshtein_tabulation is 3-5x faster than levenshtein_memoization