### PR TITLE
Use grid crate for 1D Vec to improve performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,8 @@ categories = ["algorithms"]
 readme = "README.md"
 edition = "2018"
 
+[dependencies]
+grid = "0.9.0"
+
 [dev-dependencies]
 rand = "0.8.3"

--- a/src/distance.rs
+++ b/src/distance.rs
@@ -75,8 +75,8 @@ pub fn levenshtein_tabulation<T: PartialEq>(source: &[T], target: &[T]) -> (usiz
     // table of distances
     let mut distances = get_distance_table(m, n);
 
-    for i in 1..distances.len() {
-        for j in 1..distances[0].len() {
+    for i in 1..distances.rows() {
+        for j in 1..distances.cols() {
             if source[i - 1] == target[j - 1] {
                 // The item being looked at is the same, so the distance won't increase
                 distances[i][j] = distances[i - 1][j - 1];

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -126,7 +126,7 @@ pub fn generate_edits<T: Clone + PartialEq>(
     let mut source_idx = source.len();
     let mut target_idx = target.len();
 
-    if source_idx + 1 != distances.len() || target_idx + 1 != distances[0].len() {
+    if source_idx + 1 != distances.rows() || target_idx + 1 != distances.cols() {
         return Err(LevenshteinError::InvalidDistanceMatrixError);
     }
 
@@ -188,6 +188,7 @@ pub fn generate_edits<T: Clone + PartialEq>(
 #[cfg(test)]
 mod tests {
     use crate::edit::*;
+    use grid::grid;
 
     // Copied verbatim from
     // https://stackoverflow.com/questions/29504514/whats-the-best-way-to-compare-2-vectors-or-strings-element-by-element
@@ -203,16 +204,16 @@ mod tests {
 
         // This is the distance matrix for the strings
         // SATURDAY and SUNDAY
-        let distances = vec![
-            vec![0, 1, 2, 3, 4, 5, 6],
-            vec![1, 0, 1, 2, 3, 4, 5],
-            vec![2, 1, 1, 2, 3, 3, 4],
-            vec![3, 2, 2, 2, 3, 4, 4],
-            vec![4, 3, 2, 3, 3, 4, 5],
-            vec![5, 4, 3, 3, 4, 4, 5],
-            vec![6, 5, 4, 4, 3, 4, 5],
-            vec![7, 6, 5, 5, 4, 3, 4],
-            vec![8, 7, 6, 6, 5, 4, 3],
+        let distances = grid![
+            [0, 1, 2, 3, 4, 5, 6]
+            [1, 0, 1, 2, 3, 4, 5]
+            [2, 1, 1, 2, 3, 3, 4]
+            [3, 2, 2, 2, 3, 4, 4]
+            [4, 3, 2, 3, 3, 4, 5]
+            [5, 4, 3, 3, 4, 4, 5]
+            [6, 5, 4, 4, 3, 4, 5]
+            [7, 6, 5, 5, 4, 3, 4]
+            [8, 7, 6, 6, 5, 4, 3]
         ];
 
         let expected_edits = vec![

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,12 +1,12 @@
-pub type DistanceMatrix = Vec<Vec<usize>>;
+use grid::Grid;
+
+pub type DistanceMatrix = Grid<usize>;
 
 pub fn print_table(table: &DistanceMatrix) {
-    for row in table {
-        for item in row {
-            print!("{} ", item);
-        }
+    (0..table.rows()).for_each(|row| {
+        table.iter_row(row).for_each(|item| print!(" {}", item));
         println!("");
-    }
+    });
 }
 
 // Returns an initialized distance table of dimensions m+1 * n+1
@@ -14,18 +14,9 @@ pub fn print_table(table: &DistanceMatrix) {
 // The First column is 0..m+1
 // And the rest of the values are usize::MAX
 pub fn get_distance_table(m: usize, n: usize) -> DistanceMatrix {
-    let mut distances = Vec::with_capacity(m + 1);
-
-    // The first row
-    distances.push((0..n + 1).collect());
-
-    for i in 1..m + 1 {
-        // initialize the whole row to sentinel
-        distances.push(vec![usize::MAX; n + 1]);
-        // update the first item in the row
-        distances[i][0] = i;
-    }
-
+    let mut distances = Grid::init(m + 1, n + 1, usize::MAX);
+    (0..=n).for_each(|i| distances[0][i] = i);
+    (1..=m).for_each(|i| distances[i][0] = i);
     distances
 }
 


### PR DESCRIPTION
See #8. Benchmarking branch shows the 1D vector can be close to 2 times faster for `levenshtein_tabulation`.`levenshtein_memoization` improves but not by much. `levenshtein_naive` of course is unaffected.

Adds a dependency to [grid](https://docs.rs/grid/latest/grid/index.html). I could add some boilerplate code that would replace the crate if you think that's a good idea.